### PR TITLE
Make yum plugin work in RHEL/CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The following [rpm metadata](http://ftp.rpm.org/max-rpm/s1-rpm-inside-tags.html)
 1. BuildTime (required, automatically set by `rpmbuild`) - Used by the plugin to validate if the package is newer than what was last seen by GoCD. GoCD displays this field as Modified On.
 2. Packager - GoCD displays this field as Modified By. If not provided, it is shown as anonymous
 3. URL - Displayed as a Trackback URL by GoCD. Use this as a means to trace back to the job that published the package (within GoCD or outside) to the yum repository.
-4. BuildHost - Displayed by GoCD as Comment: Built on `$BUILDHOST`
 
 ## Published Environment Variables
 

--- a/gocd-yum-repo-plugin/build.gradle
+++ b/gocd-yum-repo-plugin/build.gradle
@@ -16,15 +16,16 @@
 
 dependencies {
   compile project(':plugin-common')
-  compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '20.1.0'
+  compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '20.6.0'
 
-  compile group: 'commons-io', name: 'commons-io', version: '2.6'
-  compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.11'
+  compile group: 'commons-io', name: 'commons-io', version: '2.7'
+  compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
 
-  testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.4.0'
+  testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.8.0'
 
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
-  testCompile group: 'junit', name: 'junit', version: '4.13'
+  testCompile group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.6.2'
+  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
 }
 
 sourceSets {
@@ -36,13 +37,12 @@ sourceSets {
   }
 }
 
-jar {
+test {
+  useJUnitPlatform()
+}
 
+jar {
   from(configurations.compile) {
     into "lib/"
   }
-//
-//    from(sourceSets.main.java) {
-//        into "/"
-//    }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/CredentialsTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/CredentialsTest.java
@@ -18,41 +18,40 @@ package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.ValidationError;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.ValidationResultMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CredentialsTest {
     @Test
     public void shouldGetUserInfo() throws Exception {
         Credentials credentials = new Credentials("user", "password");
-        assertThat(credentials.getUserInfo(), is("user:password"));
+        assertEquals("user:password", credentials.getUserInfo());
     }
 
     @Test
     public void shouldGetUserInfoWithEscapedPassword() throws Exception {
         Credentials credentials = new Credentials("user", "!password@:");
-        assertThat(credentials.getUserInfo(), is("user:%21password%40%3A"));
+        assertEquals("user:%21password%40%3A", credentials.getUserInfo());
     }
 
     @Test
     public void shouldEncodeURLCorrectlyWhenUsernameIsEmailAddress() throws Exception {
         Credentials credentials = new Credentials("user@example.com", "!password@:");
-        assertThat(credentials.getUserInfo(), is("user%40example.com:%21password%40%3A"));
+        assertEquals("user%40example.com:%21password%40%3A", credentials.getUserInfo());
     }
 
     @Test
-    public void shouldFailValidationIfOnlyPasswordProvided() throws Exception {
+    public void shouldFailValidationIfOnlyPasswordProvided() {
         ValidationResultMessage validationResult = new ValidationResultMessage();
         new Credentials(null, "password").validate(validationResult);
-        assertThat(validationResult.failure(), is(true));
+        assertTrue(validationResult.failure());
         assertTrue(validationResult.getValidationErrors().contains(new ValidationError(Constants.USERNAME, "Both Username and password are required.")));
 
         validationResult = new ValidationResultMessage();
         new Credentials("user", "").validate(validationResult);
-        assertThat(validationResult.failure(), is(true));
+        assertTrue(validationResult.failure());
         assertTrue(validationResult.getValidationErrors().contains(new ValidationError(Constants.PASSWORD, "Both Username and password are required.")));
     }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/FileBasedConnectionCheckerTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/FileBasedConnectionCheckerTest.java
@@ -16,13 +16,12 @@
 
 package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FileBasedConnectionCheckerTest {
 
@@ -39,7 +38,7 @@ public class FileBasedConnectionCheckerTest {
             new FileBasedConnectionChecker().checkConnection("file://" + absolutePath, new Credentials("user", "pwd"));
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("File protocol does not support username and/or password."));
+            assertEquals("File protocol does not support username and/or password.", e.getMessage());
         }
     }
 
@@ -49,7 +48,7 @@ public class FileBasedConnectionCheckerTest {
             new FileBasedConnectionChecker().checkConnection("file://foo", new Credentials(null, null));
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Invalid file path."));
+            assertEquals("Invalid file path.", e.getMessage());
         }
     }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/HttpConnectionCheckerTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/HttpConnectionCheckerTest.java
@@ -20,28 +20,24 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpConnectionCheckerTest {
 
     private HttpConnectionChecker checker;
     private MockWebServer webServer;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         webServer = new MockWebServer();
         checker = new HttpConnectionChecker();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         webServer.shutdown();
     }
@@ -70,16 +66,16 @@ public class HttpConnectionCheckerTest {
 
         RecordedRequest recordedRequest = webServer.takeRequest();
         assertEquals("/repodata/repomd.xml", recordedRequest.getPath());
-        assertThat(recordedRequest.getHeaders().get("Authorization"), is((String) null));
+        assertNull(recordedRequest.getHeaders().get("Authorization"));
 
         recordedRequest = webServer.takeRequest();
         assertEquals("/repodata/repomd.xml", recordedRequest.getPath());
-        assertThat(recordedRequest.getHeaders().get("Authorization"), is("Basic Zm9vOmJhcg=="));
+        assertEquals("Basic Zm9vOmJhcg==", recordedRequest.getHeaders().get("Authorization"));
     }
 
 
     @Test
-    public void shouldFailCheckConnectionToTheRepoWhenHttpClientReturnsAUnSuccessfulReturnCode() throws IOException {
+    public void shouldFailCheckConnectionToTheRepoWhenHttpClientReturnsAUnSuccessfulReturnCode() {
         webServer.enqueue(new MockResponse().setResponseCode(500));
         HttpUrl url = webServer.url("/repodata/repomd.xml");
 
@@ -87,18 +83,18 @@ public class HttpConnectionCheckerTest {
             checker.checkConnection(url.toString(), new Credentials(null, null));
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("HTTP/1.1 500 Server Error"));
+            assertEquals("HTTP/1.1 500 Server Error", e.getMessage());
         }
         assertEquals(1, webServer.getRequestCount());
     }
 
     @Test
-    public void shouldFailCheckConnectionToTheRepoWhenHttpClientThrowsIOException() throws IOException {
+    public void shouldFailCheckConnectionToTheRepoWhenHttpClientThrowsIOException() {
         try {
             checker.checkConnection("https://localhost:11111", new Credentials(null, null));
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Connection refused"));
+            assertTrue(e.getMessage().contains("Connection refused"));
         }
     }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/PackageRepositoryConfigurationProviderTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/PackageRepositoryConfigurationProviderTest.java
@@ -19,24 +19,21 @@ import com.tw.go.plugin.material.artifactrepository.yum.exec.message.PackageMate
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.PackageMaterialProperty;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.ValidationError;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.ValidationResultMessage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PackageRepositoryConfigurationProviderTest {
 
     private PackageRepositoryConfigurationProvider configurationProvider;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         configurationProvider = new PackageRepositoryConfigurationProvider();
     }
 
@@ -45,44 +42,44 @@ public class PackageRepositoryConfigurationProviderTest {
 
         PackageMaterialProperties configuration = configurationProvider.repositoryConfiguration();
 
-        assertThat(configuration.getProperty(Constants.REPO_URL), notNullValue());
-        assertThat(configuration.getProperty(Constants.REPO_URL).partOfIdentity(), nullValue());
-        assertThat(configuration.getProperty(Constants.REPO_URL).required(), nullValue());
-        assertThat(configuration.getProperty(Constants.REPO_URL).secure(), nullValue());
-        assertThat(configuration.getProperty(Constants.REPO_URL).displayName(), is("Repository URL"));
-        assertThat(configuration.getProperty(Constants.REPO_URL).displayOrder(), is("0"));
+        assertNotNull(configuration.getProperty(Constants.REPO_URL));
+        assertNull(configuration.getProperty(Constants.REPO_URL).partOfIdentity());
+        assertNull(configuration.getProperty(Constants.REPO_URL).required());
+        assertNull(configuration.getProperty(Constants.REPO_URL).secure());
+        assertEquals("Repository URL", configuration.getProperty(Constants.REPO_URL).displayName());
+        assertEquals("0", configuration.getProperty(Constants.REPO_URL).displayOrder());
 
-        assertThat(configuration.getProperty(Constants.USERNAME), notNullValue());
-        assertThat(configuration.getProperty(Constants.USERNAME).partOfIdentity(), is(false));
-        assertThat(configuration.getProperty(Constants.USERNAME).required(), is(false));
-        assertThat(configuration.getProperty(Constants.USERNAME).secure(), nullValue());
-        assertThat(configuration.getProperty(Constants.USERNAME).displayName(), is("User"));
-        assertThat(configuration.getProperty(Constants.USERNAME).displayOrder(), is("1"));
+        assertNotNull(configuration.getProperty(Constants.USERNAME));
+        assertFalse(configuration.getProperty(Constants.USERNAME).partOfIdentity());
+        assertFalse(configuration.getProperty(Constants.USERNAME).required());
+        assertNull(configuration.getProperty(Constants.USERNAME).secure());
+        assertEquals("User", configuration.getProperty(Constants.USERNAME).displayName());
+        assertEquals("1", configuration.getProperty(Constants.USERNAME).displayOrder());
 
-        assertThat(configuration.getProperty(Constants.PASSWORD), notNullValue());
-        assertThat(configuration.getProperty(Constants.PASSWORD).partOfIdentity(), is(false));
-        assertThat(configuration.getProperty(Constants.PASSWORD).required(), is(false));
-        assertThat(configuration.getProperty(Constants.PASSWORD).secure(), is(true));
-        assertThat(configuration.getProperty(Constants.PASSWORD).displayName(), is("Password"));
-        assertThat(configuration.getProperty(Constants.PASSWORD).displayOrder(), is("2"));
+        assertNotNull(configuration.getProperty(Constants.PASSWORD));
+        assertFalse(configuration.getProperty(Constants.PASSWORD).partOfIdentity());
+        assertFalse(configuration.getProperty(Constants.PASSWORD).required());
+        assertTrue(configuration.getProperty(Constants.PASSWORD).secure());
+        assertEquals("Password", configuration.getProperty(Constants.PASSWORD).displayName());
+        assertEquals("2", configuration.getProperty(Constants.PASSWORD).displayOrder());
     }
 
     @Test
     public void shouldGetPackageConfiguration() {
         PackageMaterialProperties configuration = configurationProvider.packageConfiguration();
-        assertThat(configuration.getProperty(Constants.PACKAGE_SPEC), notNullValue());
-        assertThat(configuration.getProperty(Constants.PACKAGE_SPEC).displayName(), is("Package Spec"));
-        assertThat(configuration.getProperty(Constants.PACKAGE_SPEC).displayOrder(), is("0"));
+        assertNotNull(configuration.getProperty(Constants.PACKAGE_SPEC));
+        assertEquals("Package Spec", configuration.getProperty(Constants.PACKAGE_SPEC).displayName());
+        assertEquals("0", configuration.getProperty(Constants.PACKAGE_SPEC).displayOrder());
     }
 
     @Test
     public void shouldCheckIfRepositoryConfigurationValid() {
-        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(new PackageMaterialProperties()), asList(new ValidationError(Constants.REPO_URL, "Repository url not specified")), false);
-        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, null)), asList(new ValidationError(Constants.REPO_URL, "Repository url is empty")), false);
-        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "")), asList(new ValidationError(Constants.REPO_URL, "Repository url is empty")), false);
-        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "incorrectUrl")), asList(new ValidationError(Constants.REPO_URL, "Invalid URL : incorrectUrl")), false);
-        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "http://correct.com/url")), new ArrayList<ValidationError>(), true);
-        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "http://correct.com/url")), new ArrayList<ValidationError>(), true);
+        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(new PackageMaterialProperties()), singletonList(new ValidationError(Constants.REPO_URL, "Repository url not specified")), false);
+        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, null)), singletonList(new ValidationError(Constants.REPO_URL, "Repository url is empty")), false);
+        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "")), singletonList(new ValidationError(Constants.REPO_URL, "Repository url is empty")), false);
+        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "incorrectUrl")), singletonList(new ValidationError(Constants.REPO_URL, "Invalid URL : incorrectUrl")), false);
+        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "http://correct.com/url")), emptyList(), true);
+        assertConfigurationErrors(configurationProvider.validateRepositoryConfiguration(configurations(Constants.REPO_URL, "http://correct.com/url")), emptyList(), true);
     }
 
     @Test
@@ -91,17 +88,17 @@ public class PackageRepositoryConfigurationProviderTest {
         configurationProvidedByUser.addPackageMaterialProperty(Constants.REPO_URL, new PackageMaterialProperty().withValue("http://correct.com/url"));
         configurationProvidedByUser.addPackageMaterialProperty("invalid-keys", new PackageMaterialProperty().withValue("some value"));
         ValidationResultMessage validationResultMessage = configurationProvider.validateRepositoryConfiguration(configurationProvidedByUser);
-        assertConfigurationErrors(validationResultMessage, asList(new ValidationError("", "Unsupported key(s) found : invalid-keys. Allowed key(s) are : REPO_URL, USERNAME, PASSWORD")), false);
+        assertConfigurationErrors(validationResultMessage, singletonList(new ValidationError("", "Unsupported key(s) found : invalid-keys. Allowed key(s) are : REPO_URL, USERNAME, PASSWORD")), false);
     }
 
 
     @Test
     public void shouldCheckIfPackageConfigurationValid() {
-        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(new PackageMaterialProperties()), asList(new ValidationError(Constants.PACKAGE_SPEC, "Package spec not specified")), false);
-        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, null)), asList(new ValidationError(Constants.PACKAGE_SPEC, "Package spec is null")), false);
-        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, "")), asList(new ValidationError(Constants.PACKAGE_SPEC, "Package spec is empty")), false);
-        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, "go-age?nt-*")), new ArrayList<ValidationError>(), true);
-        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, "go-agent")), new ArrayList<ValidationError>(), true);
+        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(new PackageMaterialProperties()), singletonList(new ValidationError(Constants.PACKAGE_SPEC, "Package spec not specified")), false);
+        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, null)), singletonList(new ValidationError(Constants.PACKAGE_SPEC, "Package spec is null")), false);
+        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, "")), singletonList(new ValidationError(Constants.PACKAGE_SPEC, "Package spec is empty")), false);
+        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, "go-age?nt-*")), emptyList(), true);
+        assertConfigurationErrors(configurationProvider.validatePackageConfiguration(configurations(Constants.PACKAGE_SPEC, "go-agent")), emptyList(), true);
     }
 
     @Test
@@ -110,13 +107,13 @@ public class PackageRepositoryConfigurationProviderTest {
         configurationProvidedByUser.addPackageMaterialProperty(Constants.PACKAGE_SPEC, new PackageMaterialProperty().withValue("go-agent"));
         configurationProvidedByUser.addPackageMaterialProperty("invalid-keys", new PackageMaterialProperty().withValue("some value"));
         ValidationResultMessage validationResultMessage = configurationProvider.validatePackageConfiguration(configurationProvidedByUser);
-        assertConfigurationErrors(validationResultMessage, asList(new ValidationError("", "Unsupported key(s) found : invalid-keys. Allowed key(s) are : PACKAGE_SPEC")), false);
+        assertConfigurationErrors(validationResultMessage, singletonList(new ValidationError("", "Unsupported key(s) found : invalid-keys. Allowed key(s) are : PACKAGE_SPEC")), false);
     }
 
     private void assertConfigurationErrors(ValidationResultMessage validationResult, List<ValidationError> expectedErrors, boolean expectedValidationResult) {
-        assertThat(validationResult.success(), is(expectedValidationResult));
-        assertThat(validationResult.getValidationErrors().size(), is(expectedErrors.size()));
-        assertThat(validationResult.getValidationErrors().containsAll(expectedErrors), is(true));
+        assertEquals(expectedValidationResult, validationResult.success());
+        assertEquals(expectedErrors.size(), validationResult.getValidationErrors().size());
+        assertTrue(validationResult.getValidationErrors().containsAll(expectedErrors));
     }
 
     private PackageMaterialProperties configurations(String key, String value) {

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/RepoUrlTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/RepoUrlTest.java
@@ -18,63 +18,59 @@ package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.ValidationError;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.ValidationResultMessage;
-import org.junit.Test;
-import org.mockito.Matchers;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.tw.go.plugin.material.artifactrepository.yum.exec.Constants.REPO_URL;
-import static java.util.Arrays.asList;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class RepoUrlTest {
     @Test
     public void shouldCorrectlyCheckIfRepositoryConfigurationValid() {
-        assertRepositoryUrlValidation("", null, null, asList(new ValidationError(REPO_URL, "Repository url is empty")), true);
-        assertRepositoryUrlValidation(null, null, null, asList(new ValidationError(REPO_URL, "Repository url is empty")), true);
-        assertRepositoryUrlValidation("  ", null, null, asList(new ValidationError(REPO_URL, "Repository url is empty")), true);
-        assertRepositoryUrlValidation("h://localhost", null, null, asList(new ValidationError(REPO_URL, "Invalid URL : h://localhost")), true);
-        assertRepositoryUrlValidation("ftp:///foo.bar", null, null, asList(new ValidationError(REPO_URL, "Invalid URL: Only 'file', 'http' and 'https' protocols are supported.")), true);
-        assertRepositoryUrlValidation("incorrectUrl", null, null, asList(new ValidationError(REPO_URL, "Invalid URL : incorrectUrl")), true);
-        assertRepositoryUrlValidation("http://user:password@localhost", null, null, asList(new ValidationError(REPO_URL, "User info should not be provided as part of the URL. Please provide credentials using USERNAME and PASSWORD configuration keys.")), true);
-        assertRepositoryUrlValidation("http://correct.com/url", null, null, new ArrayList<ValidationError>(), false);
-        assertRepositoryUrlValidation("file:///foo.bar", null, null, new ArrayList<ValidationError>(), false);
-        assertRepositoryUrlValidation("file:///foo.bar", "user", "password", asList(new ValidationError(REPO_URL, "File protocol does not support username and/or password.")), true);
+        assertRepositoryUrlValidation("", null, null, singletonList(new ValidationError(REPO_URL, "Repository url is empty")), true);
+        assertRepositoryUrlValidation(null, null, null, singletonList(new ValidationError(REPO_URL, "Repository url is empty")), true);
+        assertRepositoryUrlValidation("  ", null, null, singletonList(new ValidationError(REPO_URL, "Repository url is empty")), true);
+        assertRepositoryUrlValidation("h://localhost", null, null, singletonList(new ValidationError(REPO_URL, "Invalid URL : h://localhost")), true);
+        assertRepositoryUrlValidation("ftp:///foo.bar", null, null, singletonList(new ValidationError(REPO_URL, "Invalid URL: Only 'file', 'http' and 'https' protocols are supported.")), true);
+        assertRepositoryUrlValidation("incorrectUrl", null, null, singletonList(new ValidationError(REPO_URL, "Invalid URL : incorrectUrl")), true);
+        assertRepositoryUrlValidation("http://user:password@localhost", null, null, singletonList(new ValidationError(REPO_URL, "User info should not be provided as part of the URL. Please provide credentials using USERNAME and PASSWORD configuration keys.")), true);
+        assertRepositoryUrlValidation("http://correct.com/url", null, null, emptyList(), false);
+        assertRepositoryUrlValidation("file:///foo.bar", null, null, emptyList(), false);
+        assertRepositoryUrlValidation("file:///foo.bar", "user", "password", singletonList(new ValidationError(REPO_URL, "File protocol does not support username and/or password.")), true);
     }
 
     @Test
-    public void shouldThrowUpWhenFileProtocolAndCredentialsAreUsed() throws Exception {
+    public void shouldThrowUpWhenFileProtocolAndCredentialsAreUsed() {
         RepoUrl repoUrl = new RepoUrl("file://foo.bar", null, "password");
         ValidationResultMessage errors = new ValidationResultMessage();
 
         repoUrl.validate(errors);
 
-        assertThat(errors.failure(), is(true));
-        assertThat(errors.getValidationErrors().size(), is(1));
-        assertThat(errors.getValidationErrors().get(0).getMessage(), is("File protocol does not support username and/or password."));
+        assertTrue(errors.failure());
+        assertEquals(1, errors.getValidationErrors().size());
+        assertEquals("File protocol does not support username and/or password.", errors.getValidationErrors().get(0).getMessage());
     }
 
     @Test
     public void shouldReturnURLWithBasicAuth() {
         RepoUrl repoUrl = new RepoUrl("http://localhost", "user", "password");
-        assertThat(repoUrl.getUrlWithBasicAuth(), is("http://user:password@localhost"));
+        assertEquals("http://user:password@localhost", repoUrl.getUrlWithBasicAuth());
     }
 
     @Test
     public void shouldReturnTheRightConnectionCheckerBasedOnUrlScheme() {
         ConnectionChecker checker = new RepoUrl("http://foobar.com", null, null).getChecker();
-        assertThat(checker instanceof HttpConnectionChecker, is(true));
+        assertTrue(checker instanceof HttpConnectionChecker);
 
         checker = new RepoUrl("https://foobar.com", null, null).getChecker();
-        assertThat(checker instanceof HttpConnectionChecker, is(true));
+        assertTrue(checker instanceof HttpConnectionChecker);
 
         checker = new RepoUrl("file://foo/bar", null, null).getChecker();
-        assertThat(checker instanceof FileBasedConnectionChecker, is(true));
+        assertTrue(checker instanceof FileBasedConnectionChecker);
     }
 
     @Test
@@ -83,7 +79,7 @@ public class RepoUrlTest {
             new RepoUrl("://foobar.com", null, null).checkConnection();
             fail("should have failed");
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Invalid URL: java.net.MalformedURLException: no protocol: ://foobar.com"));
+            assertTrue(e.getMessage().contains("Invalid URL: java.net.MalformedURLException: no protocol: ://foobar.com"));
         }
     }
 
@@ -93,7 +89,7 @@ public class RepoUrlTest {
             new RepoUrl("httph://foobar.com", null, null).checkConnection();
             fail("should have failed");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Invalid URL: java.net.MalformedURLException: unknown protocol: httph"));
+            assertEquals("Invalid URL: java.net.MalformedURLException: unknown protocol: httph", e.getMessage());
         }
     }
 
@@ -102,12 +98,12 @@ public class RepoUrlTest {
         try {
             RepoUrl repoUrl = spy(new RepoUrl("url", null, null));
             ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
-            doThrow(new RuntimeException("Unreachable url")).when(connectionChecker).checkConnection(Matchers.<String>any(), Matchers.<Credentials>any());
+            doThrow(new RuntimeException("Unreachable url")).when(connectionChecker).checkConnection(any(), any());
             doReturn(connectionChecker).when(repoUrl).getChecker();
             repoUrl.checkConnection();
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Unreachable url"));
+            assertEquals("Unreachable url", e.getMessage());
         }
     }
 
@@ -117,7 +113,7 @@ public class RepoUrlTest {
             new RepoUrl("file:///foo/bar", null, null).checkConnection();
             fail("should fail");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Invalid file path."));
+            assertEquals("Invalid file path.", e.getMessage());
         }
     }
 
@@ -129,26 +125,26 @@ public class RepoUrlTest {
 
         repoUrl.checkConnection();
 
-        verify(connectionChecker).checkConnection(Matchers.<String>any(), Matchers.<Credentials>any());
+        verify(connectionChecker).checkConnection(any(), any());
     }
 
     @Test
-    public void shouldGetUrlForDisplay() throws Exception {
-        assertThat(new RepoUrl("file:///foo/bar", null, null).forDisplay(), is("file:///foo/bar"));
+    public void shouldGetUrlForDisplay() {
+        assertEquals("file:///foo/bar", new RepoUrl("file:///foo/bar", null, null).forDisplay());
     }
 
     @Test
-    public void shouldGetRepoMetadataUrl() throws Exception {
-        assertThat(new RepoUrl("file:///foo/bar", null, null).getRepoMetadataUrl(), is("file:///foo/bar/repodata/repomd.xml"));
-        assertThat(new RepoUrl("file:///foo/bar/", null, null).getRepoMetadataUrl(), is("file:///foo/bar/repodata/repomd.xml"));
-        assertThat(new RepoUrl("file:///foo/bar//", null, null).getRepoMetadataUrl(), is("file:///foo/bar/repodata/repomd.xml"));
+    public void shouldGetRepoMetadataUrl() {
+        assertEquals("file:///foo/bar/repodata/repomd.xml", new RepoUrl("file:///foo/bar", null, null).getRepoMetadataUrl());
+        assertEquals("file:///foo/bar/repodata/repomd.xml", new RepoUrl("file:///foo/bar/", null, null).getRepoMetadataUrl());
+        assertEquals("file:///foo/bar/repodata/repomd.xml", new RepoUrl("file:///foo/bar//", null, null).getRepoMetadataUrl());
     }
 
     private void assertRepositoryUrlValidation(String url, String username, String password, List<ValidationError> expectedErrors, boolean isFailure) {
         ValidationResultMessage errors = new ValidationResultMessage();
         new RepoUrl(url, username, password).validate(errors);
-        assertThat(errors.failure(), is(isFailure));
-        assertThat(errors.getValidationErrors().size(), is(expectedErrors.size()));
-        assertThat(errors.getValidationErrors().containsAll(expectedErrors), is(true));
+        assertEquals(isFailure, errors.failure());
+        assertEquals(expectedErrors.size(), errors.getValidationErrors().size());
+        assertTrue(errors.getValidationErrors().containsAll(expectedErrors));
     }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/RepoqueryCacheCleaner.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/RepoqueryCacheCleaner.java
@@ -19,18 +19,15 @@ package com.tw.go.plugin.material.artifactrepository.yum.exec;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 
-public class RepoqueryCacheCleaner{
+public class RepoqueryCacheCleaner {
     public static void performCleanup() throws IOException {
-        File[] cacheFiles = new File("/var/tmp/").listFiles(new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                return name.startsWith("go-yum-plugin-");
+        File[] cacheFiles = new File("/var/tmp/").listFiles((dir, name) -> name.startsWith("go-yum-plugin-"));
+        if (null != cacheFiles) {
+            for (File cacheFile : cacheFiles) {
+                FileUtils.forceDelete(cacheFile);
             }
-        });
-        for(File cacheFile : cacheFiles){
-            FileUtils.forceDelete(cacheFile);
         }
     }
 

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/YumArtifactRepositoryMaterialTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/YumArtifactRepositoryMaterialTest.java
@@ -16,188 +16,191 @@
 package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
-
 import com.thoughtworks.go.plugin.api.request.DefaultGoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.CheckConnectionResultMessage;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.PackageRevisionMessage;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Date;
 import java.util.TimeZone;
 
 import static com.tw.go.plugin.common.util.JsonUtil.fromJsonString;
 import static com.tw.go.plugin.material.artifactrepository.yum.exec.YumArtifactRepositoryMaterial.*;
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class YumArtifactRepositoryMaterialTest {
-
     private YumArtifactRepositoryMaterial material;
-    private File sampleRepoDirectory;
     private String repoUrl;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws IOException {
         material = new YumArtifactRepositoryMaterial();
         RepoqueryCacheCleaner.performCleanup();
-        sampleRepoDirectory = new File("src/test/repos/samplerepo");
+        final File sampleRepoDirectory = new File("src/test/repos/samplerepo");
         repoUrl = "file://" + sampleRepoDirectory.getAbsolutePath();
     }
 
     @Test
-    public void shouldReturnResponseForRepositoryConfiguration() throws Exception {
+    public void shouldReturnResponseForRepositoryConfiguration() {
         GoPluginApiResponse response = material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_REPOSITORY_CONFIGURATION));
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        assertThat(response.responseBody(), is("{\"REPO_URL\":{\"display-name\":\"Repository URL\",\"display-order\":\"0\"}," +
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals("{\"REPO_URL\":{\"display-name\":\"Repository URL\",\"display-order\":\"0\"}," +
                 "\"USERNAME\":{\"part-of-identity\":false,\"required\":false,\"display-name\":\"User\",\"display-order\":\"1\"}," +
                 "\"PASSWORD\":{\"secure\":true,\"part-of-identity\":false,\"required\":false,\"display-name\":\"Password\",\"display-order\":\"2\"}" +
-                "}"));
+                "}", response.responseBody());
     }
 
     @Test
-    public void shouldReturnResponseForPackageConfiguration() throws Exception {
+    public void shouldReturnResponseForPackageConfiguration() {
         GoPluginApiResponse response = material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_PACKAGE_CONFIGURATION));
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        assertThat(response.responseBody(), is("{\"PACKAGE_SPEC\":{\"display-name\":\"Package Spec\",\"display-order\":\"0\"}}"));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals("{\"PACKAGE_SPEC\":{\"display-name\":\"Package Spec\",\"display-order\":\"0\"}}", response.responseBody());
     }
 
     @Test
-    public void shouldReturnSuccessForValidateRepositoryConfiguration() throws Exception {
+    public void shouldReturnSuccessForValidateRepositoryConfiguration() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_VALIDATE_REPOSITORY_CONFIGURATION);
         request.setRequestBody("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"http://localhost.com\"}}}");
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        assertThat(response.responseBody(), is(""));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals("", response.responseBody());
     }
 
     @Test
-    public void shouldReturnFailureForValidateRepositoryConfiguration() throws Exception {
+    public void shouldReturnFailureForValidateRepositoryConfiguration() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_VALIDATE_REPOSITORY_CONFIGURATION);
         request.setRequestBody("{\"repository-configuration\":{\"RANDOM\":{\"value\":\"value\"}}}");
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        assertThat(response.responseBody(), is("[{\"key\":\"\",\"message\":\"Unsupported key(s) found : RANDOM. Allowed key(s) are : REPO_URL, USERNAME, PASSWORD\"},{\"key\":\"REPO_URL\",\"message\":\"Repository url not specified\"}]"));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals("[{\"key\":\"\",\"message\":\"Unsupported key(s) found : RANDOM. Allowed key(s) are : REPO_URL, USERNAME, PASSWORD\"},{\"key\":\"REPO_URL\",\"message\":\"Repository url not specified\"}]", response.responseBody());
     }
 
     @Test
-    public void shouldReturnSuccessForValidatePackageConfiguration() throws Exception {
+    public void shouldReturnSuccessForValidatePackageConfiguration() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_VALIDATE_PACKAGE_CONFIGURATION);
         request.setRequestBody("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"http://localhost.com\"}},\"package-configuration\":{\"PACKAGE_SPEC\":{\"value\":\"go-agent\"}}}");
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        assertThat(response.responseBody(), is(""));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals("", response.responseBody());
     }
 
     @Test
-    public void shouldReturnFailureForValidatePackageConfiguration() throws Exception {
+    public void shouldReturnFailureForValidatePackageConfiguration() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_VALIDATE_PACKAGE_CONFIGURATION);
         request.setRequestBody("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"http://localhost.com\"}},\"package-configuration\":{\"RANDOM\":{\"value\":\"go-agent\"}}}");
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        assertThat(response.responseBody(), is("[{\"key\":\"\",\"message\":\"Unsupported key(s) found : RANDOM. Allowed key(s) are : PACKAGE_SPEC\"},{\"key\":\"PACKAGE_SPEC\",\"message\":\"Package spec not specified\"}]"));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals("[{\"key\":\"\",\"message\":\"Unsupported key(s) found : RANDOM. Allowed key(s) are : PACKAGE_SPEC\"},{\"key\":\"PACKAGE_SPEC\",\"message\":\"Package spec not specified\"}]", response.responseBody());
     }
 
 
     @Test
-    public void shouldReturnSuccessForCheckRepositoryConnection() throws Exception {
+    public void shouldReturnSuccessForCheckRepositoryConnection() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_CHECK_REPOSITORY_CONNECTION);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}}}", repoUrl));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
         CheckConnectionResultMessage result = fromJsonString(response.responseBody(), CheckConnectionResultMessage.class);
-        assertThat(result.success(), is(true));
-        assertThat(result.getMessages().isEmpty(), is(false));
+        assertTrue(result.success());
+        assertFalse(result.getMessages().isEmpty());
     }
 
     @Test
-    public void shouldReturnFailureForCheckRepositoryConnection() throws Exception {
+    public void shouldReturnFailureForCheckRepositoryConnection() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_CHECK_REPOSITORY_CONNECTION);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}}}", repoUrl + "/random"));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
         CheckConnectionResultMessage result = fromJsonString(response.responseBody(), CheckConnectionResultMessage.class);
-        assertThat(result.success(), is(false));
-        assertThat(result.getMessages().isEmpty(), is(false));
+        assertFalse(result.success());
+        assertFalse(result.getMessages().isEmpty());
     }
 
     @Test
-    public void shouldReturnSuccessForCheckPackageConnection() throws Exception {
+    public void shouldReturnSuccessForCheckPackageConnection() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_CHECK_PACKAGE_CONNECTION);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}},\"package-configuration\":{\"PACKAGE_SPEC\":{\"value\":\"go-agent\"}}}", repoUrl));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
         CheckConnectionResultMessage result = fromJsonString(response.responseBody(), CheckConnectionResultMessage.class);
-        assertThat(result.success(), is(true));
-        assertThat(result.getMessages().isEmpty(), is(false));
+        assertTrue(result.success());
+        assertFalse(result.getMessages().isEmpty());
     }
 
     @Test
-    public void shouldReturnFailureForCheckPackageConnection() throws Exception {
+    public void shouldReturnFailureForCheckPackageConnection() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_CHECK_PACKAGE_CONNECTION);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}},\"package-configuration\":{\"PACKAGE_SPEC\":{\"value\":\"incorrect\"}}}", repoUrl));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
         CheckConnectionResultMessage result = fromJsonString(response.responseBody(), CheckConnectionResultMessage.class);
-        assertThat(result.success(), is(false));
-        assertThat(result.getMessages().isEmpty(), is(false));
+        assertFalse(result.success());
+        assertFalse(result.getMessages().isEmpty());
     }
 
     @Test
-    public void shouldReturnLatestPackageRevision() throws Exception {
+    public void shouldReturnLatestPackageRevision() {
         TimeZone.setDefault(TimeZone.getTimeZone("IST"));
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_LATEST_PACKAGE_REVISION);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}},\"package-configuration\":{\"PACKAGE_SPEC\":{\"value\":\"go-agent\"}}}", repoUrl));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        PackageRevisionMessage packageRevision = fromJsonString(response.responseBody(), PackageRevisionMessage.class);
-        assertThat(packageRevision.getData().isEmpty(),is(false));
-        assertThat(response.responseBody().contains("\"revision\":\"go-agent-13.1.1-16714.noarch\""), is(true));
-        assertThat(response.responseBody().contains("\"timestamp\":\"2013-04-04T11:14:18.000Z\""), is(true));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+
+        final PackageRevisionMessage packageRevision = fromJsonString(response.responseBody(), PackageRevisionMessage.class);
+
+        assertFalse(packageRevision.getData().isEmpty());
+        assertRevisionAndTime("go-agent-13.1.1-16714.noarch", "2013-04-04T11:14:18.000Z", packageRevision);
     }
 
     @Test
-    public void shouldReturnLatestPackageRevisionSince() throws Exception {
+    public void shouldReturnLatestPackageRevisionSince() {
         TimeZone.setDefault(TimeZone.getTimeZone("IST"));
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_LATEST_PACKAGE_REVISION_SINCE);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}}," +
                 "\"package-configuration\":{\"PACKAGE_SPEC\":{\"value\":\"go-agent\"}}," +
                 "\"previous-revision\":{\"revision\":\"go-agent-13.1.0-16714.noarch\",\"timestamp\":\"2013-04-03T11:14:18.000Z\",\"data\":{\"data-key-one\":\"data-value-one\",\"data-key-two\":\"data-value-two\"}}}", repoUrl));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
-        PackageRevisionMessage packageRevision = fromJsonString(response.responseBody(), PackageRevisionMessage.class);
-        assertThat(packageRevision.getData().isEmpty(),is(false));
-        assertThat(response.responseBody().contains("\"revision\":\"go-agent-13.1.1-16714.noarch\""), is(true));
-        assertThat(response.responseBody().contains("\"timestamp\":\"2013-04-04T11:14:18.000Z\""), is(true));
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
+
+        final PackageRevisionMessage packageRevision = fromJsonString(response.responseBody(), PackageRevisionMessage.class);
+
+        assertFalse(packageRevision.getData().isEmpty());
+        assertRevisionAndTime("go-agent-13.1.1-16714.noarch", "2013-04-04T11:14:18.000Z", packageRevision);
     }
 
     @Test
-    public void shouldReturnNullLatestPackageRevisionSince() throws Exception {
+    public void shouldReturnNullLatestPackageRevisionSince() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(EXTENSION, "1.0", REQUEST_LATEST_PACKAGE_REVISION_SINCE);
         request.setRequestBody(String.format("{\"repository-configuration\":{\"REPO_URL\":{\"value\":\"%s\"}}," +
                 "\"package-configuration\":{\"PACKAGE_SPEC\":{\"value\":\"go-agent\"}}," +
                 "\"previous-revision\":{\"revision\":\"go-agent-13.1.1-16714.noarch\",\"timestamp\":\"2013-04-04T11:14:18.000Z\",\"data\":{\"data-key-one\":\"data-value-one\",\"data-key-two\":\"data-value-two\"}}}", repoUrl));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseBody(), nullValue());
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertNull(response.responseBody());
+        assertEquals(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE, response.responseCode());
     }
 
     @Test
-    public void shouldReturnUnSuccessfulResponseWhenHandlerNotFondForRequest() throws Exception {
-        assertThat(material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", "invalid")).responseCode(), is(400));
-        assertThat(material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", null)).responseCode(), is(400));
-        assertThat(material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", "")).responseCode(), is(400));
+    public void shouldReturnUnSuccessfulResponseWhenHandlerNotFondForRequest() {
+        assertEquals(400, material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", "invalid")).responseCode());
+        assertEquals(400, material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", null)).responseCode());
+        assertEquals(400, material.handle(new DefaultGoPluginApiRequest(EXTENSION, "1.0", "")).responseCode());
     }
 
     @Test
-    public void shouldReturnUnSuccessfulResponseOnException() throws Exception {
+    public void shouldReturnUnSuccessfulResponseOnException() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("package-repository", "1.0", "repository-configuration");
         final MessageHandler messageHandler = mock(MessageHandler.class);
         material = new YumArtifactRepositoryMaterial() {
@@ -208,19 +211,43 @@ public class YumArtifactRepositoryMaterialTest {
         };
         when(messageHandler.handle(request)).thenThrow(new RuntimeException("failed-for-some-reason"));
         GoPluginApiResponse response = material.handle(request);
-        assertThat(response.responseCode(), is(500));
-        assertThat(response.responseBody(), is("failed-for-some-reason"));
+        assertEquals(500, response.responseCode());
+        assertEquals("failed-for-some-reason", response.responseBody());
     }
 
     @Test
-    public void shouldReturnPluginIdentifierForPackageRepository() throws Exception {
+    public void shouldReturnPluginIdentifierForPackageRepository() {
         GoPluginIdentifier pluginIdentifier = material.pluginIdentifier();
-        assertThat(pluginIdentifier.getExtension(), is(EXTENSION));
-        assertThat(pluginIdentifier.getSupportedExtensionVersions(), is(asList("1.0")));
+        assertEquals(EXTENSION, pluginIdentifier.getExtension());
+        assertEquals(Collections.singletonList("1.0"), pluginIdentifier.getSupportedExtensionVersions());
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() throws IOException {
         RepoqueryCacheCleaner.performCleanup();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void assertRevisionAndTime(String revision, String timestamp, PackageRevisionMessage packageRevision) {
+        assertEquals(revision, packageRevision.getRevision());
+        assertTrue(isWithinAMinute(parseTimestamp(timestamp), packageRevision.getTimestamp()));
+    }
+
+    /**
+     * Unlike RHEL 7, RHEL 8 (i.e., dnf repoquery) BUILDTIME field outputs the time to only minute precision as opposed
+     * to second precision. Thus, in order to support both yum repoquery and dnf repoquery, ignore the seconds when
+     * comparing timestamps.
+     *
+     * @param left  a {@link Date}
+     * @param right a {@link Date}
+     * @return true if the difference is a minute or less, false otherwise
+     */
+    private boolean isWithinAMinute(Date left, Date right) {
+        return Math.abs(left.getTime() - right.getTime()) <= 60000L;
+    }
+
+    @NotNull
+    private Date parseTimestamp(String timestamp) {
+        return Date.from(LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(timestamp.replaceAll("Z$", ""))).atZone(ZoneOffset.systemDefault()).toInstant());
     }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMapTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/YumEnvironmentMapTest.java
@@ -16,66 +16,63 @@
 
 package com.tw.go.plugin.material.artifactrepository.yum.exec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 public class YumEnvironmentMapTest {
     @Test
-    public void shouldSetHomeEnvToTempWhenDefaultHomeEnvValueIsNotSet() throws Exception {
-        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+    public void shouldSetHomeEnvToTempWhenDefaultHomeEnvValueIsNotSet() {
+        Map<String, String> expectedEnvMap = new HashMap<>();
         YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
         expectedEnvMap.put(yumEnvironmentMap.HOME, System.getProperty("java.io.tmpdir"));
         doReturn(null).when(yumEnvironmentMap).getSystemEnvVariableFor(yumEnvironmentMap.HOME);
 
         Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
 
-        assertThat(actualEnvMap.get(yumEnvironmentMap.HOME), is(expectedEnvMap.get(yumEnvironmentMap.HOME)));
+        assertEquals(expectedEnvMap.get(yumEnvironmentMap.HOME), actualEnvMap.get(yumEnvironmentMap.HOME));
     }
 
     @Test
-    public void shouldSetYumHomeEnvToTheHomeEnvVarValueAndNotDefaultWhenHOMEEnvVarIsSet() throws Exception {
-        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+    public void shouldSetYumHomeEnvToTheHomeEnvVarValueAndNotDefaultWhenHOMEEnvVarIsSet() {
+        Map<String, String> expectedEnvMap = new HashMap<>();
         YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
         expectedEnvMap.put(yumEnvironmentMap.HOME, System.getProperty("java.io.tmpdir"));
         doReturn("/Users/Ali").when(yumEnvironmentMap).getSystemEnvVariableFor(yumEnvironmentMap.HOME);
 
         Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
 
-        assertThat(actualEnvMap.get(yumEnvironmentMap.HOME), is(not(expectedEnvMap.get(yumEnvironmentMap.HOME))));
-        assertThat(actualEnvMap.get(yumEnvironmentMap.HOME), is("/Users/Ali"));
+        assertNotEquals(expectedEnvMap.get(yumEnvironmentMap.HOME), actualEnvMap.get(yumEnvironmentMap.HOME));
+        assertEquals("/Users/Ali", actualEnvMap.get(yumEnvironmentMap.HOME));
     }
 
     @Test
-    public void shouldSetVarTmpAsDefaultTempLocationForYumIfEnvGoYumTmpdirIsNotSpecified() throws Exception {
-        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+    public void shouldSetVarTmpAsDefaultTempLocationForYumIfEnvGoYumTmpdirIsNotSpecified() {
+        Map<String, String> expectedEnvMap = new HashMap<>();
         YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
         expectedEnvMap.put(yumEnvironmentMap.TMPDIR, yumEnvironmentMap.defaultTempYumRepoDir);
         doReturn(null).when(yumEnvironmentMap).getSystemEnvVariableFor("go.yum.tmpdir");
 
         Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
 
-        assertThat(actualEnvMap.get(yumEnvironmentMap.TMPDIR), containsString(expectedEnvMap.get(yumEnvironmentMap.TMPDIR)));
+        assertTrue(actualEnvMap.get(yumEnvironmentMap.TMPDIR).contains(expectedEnvMap.get(yumEnvironmentMap.TMPDIR)));
     }
 
     @Test
-    public void shouldSetTempLocationForYumToTheDirectorySpecifiedBySystemProperty() throws Exception {
-        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+    public void shouldSetTempLocationForYumToTheDirectorySpecifiedBySystemProperty() {
+        Map<String, String> expectedEnvMap = new HashMap<>();
         YumEnvironmentMap yumEnvironmentMap = spy(new YumEnvironmentMap("someId"));
         expectedEnvMap.put(yumEnvironmentMap.TMPDIR, yumEnvironmentMap.defaultTempYumRepoDir);
         doReturn("some/location").when(yumEnvironmentMap).getSystemPropertyValueFor("go.yum.tmpdir", yumEnvironmentMap.defaultTempYumRepoDir);
 
         Map<String, String> actualEnvMap = yumEnvironmentMap.buildYumEnvironmentMap();
 
-        assertThat(actualEnvMap.get(yumEnvironmentMap.TMPDIR), containsString("some/location"));
-        assertThat(actualEnvMap.get(yumEnvironmentMap.TMPDIR), not(containsString(expectedEnvMap.get(yumEnvironmentMap.TMPDIR))));
+        assertTrue(actualEnvMap.get(yumEnvironmentMap.TMPDIR).contains("some/location"));
+        assertFalse(actualEnvMap.get(yumEnvironmentMap.TMPDIR).contains(expectedEnvMap.get(yumEnvironmentMap.TMPDIR)));
     }
 }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/ProcessRunnerTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/ProcessRunnerTest.java
@@ -16,50 +16,46 @@
 
 package com.tw.go.plugin.material.artifactrepository.yum.exec.command;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
+import java.util.Collections;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ProcessRunnerTest {
     @Test
     public void shouldRunACommand() {
-        ProcessOutput output = new ProcessRunner().execute(new String[]{"echo", "foo"}, new HashMap<String, String>());
-        assertThat(output.getStdOut().get(0), is("foo"));
-        assertThat(output.getReturnCode(), is(0));
+        ProcessOutput output = new ProcessRunner().execute(new String[]{"echo", "foo"}, Collections.emptyMap());
+        assertEquals("foo", output.getStdOut().get(0));
+        assertEquals(0, output.getReturnCode());
     }
 
     @Test
     public void shouldThrowExceptionIfCommandThrowsAnException() {
         try {
-            new ProcessRunner().execute(new String[]{"doesNotExist"}, new HashMap<String, String>());
+            new ProcessRunner().execute(new String[]{"doesNotExist"}, Collections.emptyMap());
             fail("Should have thrown exception");
         } catch (Exception e) {
-            assertThat(e instanceof RuntimeException, is(true));
+            assertTrue(e instanceof RuntimeException);
             if (isWindows()) {
-                assertThat(e.getMessage(), containsString("'doesNotExist' is not recognized as an internal or external command"));
+                assertTrue(e.getMessage().contains("'doesNotExist' is not recognized as an internal or external command"));
             } else {
-                assertThat(e.getMessage(), containsString("Cannot run program \"doesNotExist\""));
+                assertTrue(e.getMessage().contains("Cannot run program \"doesNotExist\""));
             }
         }
     }
 
     @Test
     public void shouldReturnErrorOutputIfCommandFails() {
-        ProcessOutput output = null;
+        ProcessOutput output;
         if (isWindows()) {
             output = new ProcessRunner().execute(new String[]{"dir", "foo:"}, null);
-            assertThat(output.getStdErrorAsString(), containsString("File Not Found"));
+            assertTrue(output.getStdErrorAsString().contains("File Not Found"));
         } else {
-            output = new ProcessRunner().execute(new String[]{"ls", "/foo"}, new HashMap<String, String>());
-            assertThat(output.getStdErrorAsString(), containsString("Error Message: ls: cannot access /foo: No such file or directory"));
+            output = new ProcessRunner().execute(new String[]{"ls", "/foo"}, Collections.emptyMap());
+            assertTrue(output.getStdErrorAsString().matches("Error Message: ls: cannot access [']?/foo[']?: No such file or directory"));
         }
-        assertThat(output.getReturnCode(), is(not(0)));
+        assertNotEquals(0, output.getReturnCode());
     }
 
     private boolean isWindows() {

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
@@ -21,25 +21,19 @@ import com.tw.go.plugin.material.artifactrepository.yum.exec.Constants;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.RepoUrl;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.RepoqueryCacheCleaner;
 import com.tw.go.plugin.material.artifactrepository.yum.exec.message.PackageRevisionMessage;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.*;
 
 import static com.tw.go.plugin.material.artifactrepository.yum.exec.command.RepoQueryCommand.DELIMITER;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class RepoQueryCommandTest {
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         RepoqueryCacheCleaner.performCleanup();
     }
@@ -53,18 +47,17 @@ public class RepoQueryCommandTest {
         String repoFromPath = repoid + "," + repourl;
         String[] expectedCommand = repoQueryCommand(repoid, spec, repoFromPath);
 
-        ArrayList<String> stdOut = new ArrayList<String>();
+        ArrayList<String> stdOut = new ArrayList<>();
         long time = 5;
-        stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job", "ca.hostname"));
-        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job"));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<>()));
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, new RepoQueryParams(repoid, new RepoUrl(repourl, null, null), spec)).execute();
 
-        assertThat(packageRevision.getRevision(), is("name-version-release.arch"));
-        assertThat(packageRevision.getTimestamp(), is(new Date(5000)));
-        assertThat(packageRevision.getUser(), is("packager"));
-        assertThat(packageRevision.getData().get(Constants.PACKAGE_LOCATION), is("http://location"));
-        assertThat(packageRevision.getTrackbackUrl(), is("http://jenkins.job"));
-        assertThat(packageRevision.getRevisionComment(), is("Built on ca.hostname"));
+        assertEquals("name-version-release.arch", packageRevision.getRevision());
+        assertEquals(new Date(5000), packageRevision.getTimestamp());
+        assertEquals("packager", packageRevision.getUser());
+        assertEquals("http://location", packageRevision.getData().get(Constants.PACKAGE_LOCATION));
+        assertEquals("http://jenkins.job", packageRevision.getTrackbackUrl());
         verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
@@ -77,33 +70,33 @@ public class RepoQueryCommandTest {
         String repoFromPath = repoid + "," + repourl;
         String[] expectedCommand = repoQueryCommand(repoid, spec, repoFromPath);
 
-        ArrayList<String> stdOut = new ArrayList<String>();
+        ArrayList<String> stdOut = new ArrayList<>();
         long time = 5;
-        stdOut.add(repoQueryOutput(time, "None", "NONE", "NOne", "none"));
+        stdOut.add(repoQueryOutput(time, "None", "NONE", "NOne"));
 
-        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<>()));
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, new RepoQueryParams(repoid, new RepoUrl(repourl, null, null), spec)).execute();
 
-        assertThat(packageRevision.getRevision(), is("name-version-release.arch"));
-        assertThat(packageRevision.getTimestamp(), is(new Date(5000)));
-        assertThat(packageRevision.getUser(), is(nullValue()));
-        assertThat(packageRevision.getData().get(Constants.PACKAGE_LOCATION), is(nullValue()));
-        assertThat(packageRevision.getTrackbackUrl(), is(nullValue()));
-        assertThat(packageRevision.getRevisionComment(), is(nullValue()));
+        assertEquals("name-version-release.arch", packageRevision.getRevision());
+        assertEquals(new Date(5000), packageRevision.getTimestamp());
+        assertNull(packageRevision.getUser());
+        assertNull(packageRevision.getData().get(Constants.PACKAGE_LOCATION));
+        assertNull(packageRevision.getTrackbackUrl());
+        assertNull(packageRevision.getRevisionComment());
         verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
     @Test
     public void shouldThrowExceptionIfCommandFails() {
         ProcessRunner processRunner = mock(ProcessRunner.class);
-        ArrayList<String> stdErr = new ArrayList<String>();
+        ArrayList<String> stdErr = new ArrayList<>();
         stdErr.add("err msg");
-        when(processRunner.execute(Matchers.<String[]>any(), Matchers.<Map<String, String>>any())).thenReturn(new ProcessOutput(1, null, stdErr));
+        when(processRunner.execute(any(), any())).thenReturn(new ProcessOutput(1, null, stdErr));
         try {
             new RepoQueryCommand(processRunner, new RepoQueryParams("repoid", new RepoUrl("http://url", null, null), "spec")).execute();
             fail("expected exception");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Error while querying repository with path 'http://url' and package spec 'spec'. Error Message: err msg"));
+            assertEquals("Error while querying repository with path 'http://url' and package spec 'spec'. Error Message: err msg", e.getMessage());
         }
     }
 
@@ -116,13 +109,13 @@ public class RepoQueryCommandTest {
         String repoFromPath = "repoid,http://username:%214321abcd@repohost:1111/some/path";
         String[] expectedCommand = repoQueryCommand(repoid, spec, repoFromPath);
 
-        ArrayList<String> stdOut = new ArrayList<String>();
+        ArrayList<String> stdOut = new ArrayList<>();
         long time = 5;
-        stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job", "ca.hostname"));
-        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        stdOut.add(repoQueryOutput(time, "packager", "http://location", "http://jenkins.job"));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<>()));
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, "username", "!4321abcd"), spec);
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, params).execute();
-        assertThat(packageRevision, is(not(nullValue())));
+        assertNotNull(packageRevision);
         verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
@@ -135,14 +128,14 @@ public class RepoQueryCommandTest {
         String repoFromPath = "repoid,http://username:%214321abcd@repohost:1111/some/path";
         String[] expectedCommand = repoQueryCommand(repoid, spec, repoFromPath);
 
-        ArrayList<String> stdOut = new ArrayList<String>();
+        ArrayList<String> stdOut = new ArrayList<>();
         long time = 5;
-        stdOut.add(repoQueryOutput(time, "packager", "http://foo.com/bar", "http://jenkins.job", "ca.hostname"));
+        stdOut.add(repoQueryOutput(time, "packager", "http://foo.com/bar", "http://jenkins.job"));
 
-        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<>()));
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, "username", "!4321abcd"), spec);
         PackageRevisionMessage packageRevision = new RepoQueryCommand(processRunner, params).execute();
-        assertThat(packageRevision.getData().get(Constants.PACKAGE_LOCATION), is("http://foo.com/bar"));
+        assertEquals("http://foo.com/bar", packageRevision.getData().get(Constants.PACKAGE_LOCATION));
         verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
     }
 
@@ -155,20 +148,20 @@ public class RepoQueryCommandTest {
         String repoFromPath = "repoid,http://username:%214321abcd@repohost:1111/some/path";
         String[] expectedCommand = repoQueryCommand(repoid, spec, repoFromPath);
 
-        ArrayList<String> stdOut = new ArrayList<String>();
+        ArrayList<String> stdOut = new ArrayList<>();
         long time = 5;
 
         stdOut.add("getPackage/go-agent-13.1.0-13422.noarch.rpm" + DELIMITER + "go-agent" + DELIMITER + "13.1.0" + DELIMITER + "13422" + DELIMITER + "noarch" + DELIMITER + time + DELIMITER + "packager" + DELIMITER + "http://foo.com/bar"
                 + DELIMITER + "trackback" + DELIMITER + "revision Comment");
         stdOut.add("getPackage/go-agent-13.1.0-13422.x86_64.rpm" + DELIMITER + "go-agent" + DELIMITER + "13.1.0" + DELIMITER + "13422" + DELIMITER + "x86_64" + DELIMITER + time + DELIMITER + "packager" +
                 DELIMITER + "http://foo.com/bar" + DELIMITER + "trackback" + DELIMITER + "revision Comment");
-        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<String>()));
+        when(processRunner.execute(expectedCommand, envMapWithDefaultValues(repoid))).thenReturn(new ProcessOutput(0, stdOut, new ArrayList<>()));
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, "username", "!4321abcd"), spec);
         try {
             new RepoQueryCommand(processRunner, params).execute();
             fail("expected failure");
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Given Package Spec (go-agent) resolves to more than one file on the repository: go-agent-13.1.0-13422.noarch.rpm, go-agent-13.1.0-13422.x86_64.rpm"));
+            assertTrue(e.getMessage().contains("Given Package Spec (go-agent) resolves to more than one file on the repository: go-agent-13.1.0-13422.noarch.rpm, go-agent-13.1.0-13422.x86_64.rpm"));
             verify(processRunner).execute(expectedCommand, envMapWithDefaultValues(repoid));
         }
     }
@@ -176,13 +169,9 @@ public class RepoQueryCommandTest {
     @Test
     public void shouldHandleMultipleThreads() throws InterruptedException {
         final StringBuilder errors = new StringBuilder();
-        Thread.UncaughtExceptionHandler handler = new Thread.UncaughtExceptionHandler() {
-            public void uncaughtException(Thread t, Throwable e) {
-                errors.append(t.getName() + " : " + e.getMessage());
-            }
-        };
+        Thread.UncaughtExceptionHandler handler = (t, e) -> errors.append(t.getName()).append(" : ").append(e.getMessage());
         String repoId = UUID.randomUUID().toString();
-        ArrayList<Thread> threads = new ArrayList<Thread>();
+        ArrayList<Thread> threads = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             Thread thread = new Thread(new CommandThread(repoId));
             thread.setUncaughtExceptionHandler(handler);
@@ -198,8 +187,8 @@ public class RepoQueryCommandTest {
         }
     }
 
-    private String repoQueryOutput(long time, String packager, String location, String trackbackUrl, String buildHost) {
-        return "relativepath" + DELIMITER + "name" + DELIMITER + "version" + DELIMITER + "release" + DELIMITER + "arch" + DELIMITER + time + DELIMITER + packager + DELIMITER + location + DELIMITER + trackbackUrl + DELIMITER + buildHost;
+    private String repoQueryOutput(long time, String packager, String location, String trackbackUrl) {
+        return "relativepath" + DELIMITER + "name" + DELIMITER + "version" + DELIMITER + "release" + DELIMITER + "arch" + DELIMITER + time + DELIMITER + packager + DELIMITER + location + DELIMITER + trackbackUrl;
     }
 
     private String[] repoQueryCommand(String repoid, String spec, String repoFromPath) {
@@ -209,19 +198,19 @@ public class RepoQueryCommandTest {
                 "-q",
                 spec,
                 "--qf",
-                "%{RELATIVEPATH}" + DELIMITER + "%{NAME}" + DELIMITER + "%{VERSION}" + DELIMITER + "%{RELEASE}" + DELIMITER + "%{ARCH}" + DELIMITER + "%{BUILDTIME}" + DELIMITER + "%{PACKAGER}" + DELIMITER + "%{LOCATION}" + DELIMITER + "%{URL}" + DELIMITER + "%{BUILDHOST}"};
+                "%{RELATIVEPATH}" + DELIMITER + "%{NAME}" + DELIMITER + "%{VERSION}" + DELIMITER + "%{RELEASE}" + DELIMITER + "%{ARCH}" + DELIMITER + "%{BUILDTIME}" + DELIMITER + "%{PACKAGER}" + DELIMITER + "%{LOCATION}" + DELIMITER + "%{URL}"};
     }
 
     private Map<String, String> envMapWithDefaultValues(String repoid) {
-        Map<String, String> expectedEnvMap = new HashMap<String, String>();
+        Map<String, String> expectedEnvMap = new HashMap<>();
         expectedEnvMap.put("HOME", System.getenv("HOME"));
         expectedEnvMap.put("TMPDIR", String.format("/var/tmp/go-yum-plugin-%s", repoid));
         return expectedEnvMap;
     }
 
-    class CommandThread implements Runnable {
-        private String repoId;
-        private String repoUrl;
+    static class CommandThread implements Runnable {
+        private final String repoId;
+        private final String repoUrl;
 
         CommandThread(String repoId) {
             this.repoId = repoId;
@@ -233,7 +222,7 @@ public class RepoQueryCommandTest {
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         RepoqueryCacheCleaner.performCleanup();
     }

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryParamsTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryParamsTest.java
@@ -17,16 +17,13 @@
 package com.tw.go.plugin.material.artifactrepository.yum.exec.command;
 
 import com.tw.go.plugin.material.artifactrepository.yum.exec.RepoUrl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RepoQueryParamsTest {
     @Test
-    public void shouldReturnUrlWithEscapedPassword() throws Exception {
+    public void shouldReturnUrlWithEscapedPassword() {
         String repoid = "repoid";
         String repourl = "http://repohost:1111/some/path#fragment?q=foo";
         String spec = "pkg-spec";
@@ -34,26 +31,26 @@ public class RepoQueryParamsTest {
         String password = "!4321abcd";
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, username, password), spec);
 
-        assertThat(params.getRepoFromId(), is("repoid,http://username:%214321abcd@repohost:1111/some/path#fragment?q=foo"));
+        assertEquals("repoid,http://username:%214321abcd@repohost:1111/some/path#fragment?q=foo", params.getRepoFromId());
     }
 
     @Test
-    public void shouldThrowExceptionIfRepoUrlIsInvalid() throws Exception {
+    public void shouldThrowExceptionIfRepoUrlIsInvalid() {
         try {
             new RepoQueryParams("repoid", new RepoUrl("://some/path", "username", "!4321abcd"), "pkg-spec").getRepoFromId();
             fail("should throw exception");
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("java.net.MalformedURLException"));
+            assertTrue(e.getMessage().contains("java.net.MalformedURLException"));
         }
     }
 
     @Test
-    public void shouldReturnUrlAsIsIfNoCredentialsProvided() throws Exception {
+    public void shouldReturnUrlAsIsIfNoCredentialsProvided() {
         String repoid = "repoid";
         String repourl = "http://repohost:1111/some/path#fragment?q=foo";
         String spec = "pkg-spec";
         RepoQueryParams params = new RepoQueryParams(repoid, new RepoUrl(repourl, null, null), spec);
-        assertThat(params.getRepoFromId(), is("repoid,http://repohost:1111/some/path#fragment?q=foo"));
+        assertEquals("repoid,http://repohost:1111/some/path#fragment?q=foo", params.getRepoFromId());
     }
 
     @Test
@@ -63,7 +60,7 @@ public class RepoQueryParamsTest {
             params.getRepoFromId();
             fail("expected invalid uri exception");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Invalid uri format file:/path"));
+            assertEquals("Invalid uri format file:/path", e.getMessage());
         }
     }
 

--- a/plugin-common/build.gradle
+++ b/plugin-common/build.gradle
@@ -15,12 +15,17 @@
  */
 
 dependencies {
-  compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '20.1.0'
+  compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '20.6.0'
 
-  compile group: 'commons-io', name: 'commons-io', version: '2.6'
-  compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.11'
-  compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-  testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.4.0'
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
-  testCompile group: 'junit', name: 'junit', version: '4.13'
+  compile group: 'commons-io', name: 'commons-io', version: '2.7'
+  compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
+  compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+  testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.8.0'
+  testCompile group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.6.2'
+  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/plugin-common/src/main/java/com/tw/go/plugin/common/util/ListUtil.java
+++ b/plugin-common/src/main/java/com/tw/go/plugin/common/util/ListUtil.java
@@ -20,13 +20,13 @@ import java.util.Collection;
 import java.util.Iterator;
 
 public class ListUtil {
-    public static String join(Collection c) {
+    public static String join(Collection<?> c) {
         return join(c, ", ");
     }
 
-    public static String join(Collection c, String join) {
-        StringBuffer sb = new StringBuffer();
-        for (Iterator<Object> iterator = c.iterator(); iterator.hasNext(); ) {
+    public static String join(Collection<?> c, String join) {
+        StringBuilder sb = new StringBuilder();
+        for (Iterator<?> iterator = c.iterator(); iterator.hasNext(); ) {
             sb.append(iterator.next());
             if (iterator.hasNext()) {
                 sb.append(join);

--- a/plugin-common/src/test/java/com/tw/go/plugin/common/util/ListUtilTest.java
+++ b/plugin-common/src/test/java/com/tw/go/plugin/common/util/ListUtilTest.java
@@ -16,29 +16,28 @@
 
 package com.tw.go.plugin.common.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListUtilTest {
     @Test
-    public void shouldJoinAListUsingComma(){
-        ArrayList<String> list = new ArrayList<String>();
+    public void shouldJoinAListUsingComma() {
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
-        assertThat(ListUtil.join(list), is("a, b, c"));
+        assertEquals("a, b, c", ListUtil.join(list));
     }
 
     @Test
-    public void shouldJoinAListUsingSpecifiedSeparator(){
-        ArrayList<String> list = new ArrayList<String>();
+    public void shouldJoinAListUsingSpecifiedSeparator() {
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
-        assertThat(ListUtil.join(list, " "), is("a b c"));
+        assertEquals("a b c", ListUtil.join(list, " "));
     }
 }

--- a/plugin-common/src/test/java/com/tw/go/plugin/common/util/StringUtilTest.java
+++ b/plugin-common/src/test/java/com/tw/go/plugin/common/util/StringUtilTest.java
@@ -16,25 +16,25 @@
 
 package com.tw.go.plugin.common.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringUtilTest {
     @Test
     public void shouldCheckAStringForBlank() {
-        assertThat(StringUtil.isBlank(""), is(true));
-        assertThat(StringUtil.isBlank("   "), is(true));
-        assertThat(StringUtil.isBlank(null), is(true));
-        assertThat(StringUtil.isBlank(" a "), is(false));
+        assertTrue(StringUtil.isBlank(""));
+        assertTrue(StringUtil.isBlank("   "));
+        assertTrue(StringUtil.isBlank(null));
+        assertFalse(StringUtil.isBlank(" a "));
     }
 
     @Test
-    public void shouldCheckIfAStringIsNotBlank() throws Exception {
-        assertThat(StringUtil.isNotBlank(""), is(false));
-        assertThat(StringUtil.isNotBlank("   "), is(false));
-        assertThat(StringUtil.isNotBlank(null), is(false));
-        assertThat(StringUtil.isNotBlank(" a "), is(true));
+    public void shouldCheckIfAStringIsNotBlank() {
+        assertFalse(StringUtil.isNotBlank(""));
+        assertFalse(StringUtil.isNotBlank("   "));
+        assertFalse(StringUtil.isNotBlank(null));
+        assertTrue(StringUtil.isNotBlank(" a "));
     }
 }


### PR DESCRIPTION
Fixes gocd/gocd#8404

dnf repoquery fields are different from RHEL 7 repoquery.

- BUILDHOST is no longer supported
- LOCATION now gives a relative path instead of fully qualified URL
- BUILDTIME now reports timestamp in `yyyy-MM-dd HH:mm` format instead
  of the POSIX seconds from epoch

Also:

- Update tests to JUnit 5; use xUnit style assertions instead of
  spec/expect style
- Update mockito, mockwebserver, commons-io, httpclient, gson, and
  go-plugin-api