### PR TITLE
Force only one result

### DIFF
--- a/gocd-yum-repo-plugin/src/main/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommand.java
+++ b/gocd-yum-repo-plugin/src/main/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommand.java
@@ -56,6 +56,7 @@ public class RepoQueryCommand {
     public PackageRevisionMessage execute() {
         YumEnvironmentMap yumEnvironmentMap = new YumEnvironmentMap(params.getRepoId());
         String[] command = {"repoquery",
+                "--latest-limit=1",
                 "--repofrompath=" + params.getRepoFromId(),
                 "--repoid=" + params.getRepoId(),
                 "-q",


### PR DESCRIPTION
Currently, when there are multiple packages which match the package spec, we see an error in this plugin due to several results from its repo query.  This PR selects the single latest only, preventing the problem.