### PR TITLE
Bump transitive commons-codec dependency to 1.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ ext {
   deps = [
     gocdPluginApi: 'cd.go.plugin:go-plugin-api:22.3.0',
     commonsIo:     'commons-io:commons-io:2.11.0',
+    commonsCodec:  'commons-codec:commons-codec:1.15',
     httpClient:    'org.apache.httpcomponents:httpclient:4.5.13',
     mockito:       'org.mockito:mockito-core:4.9.0',
     mockWebServer: 'com.squareup.okhttp3:mockwebserver:4.10.0',

--- a/plugin-common/build.gradle
+++ b/plugin-common/build.gradle
@@ -22,6 +22,12 @@ dependencies {
 
   api project.deps.commonsIo
   api project.deps.httpClient
+  constraints {
+    api(project.deps.commonsCodec) {
+      because 'Transitive dependency of apache httpclient has reported vulnerabilities'
+    }
+  }
+
   api group: 'com.google.code.gson', name: 'gson', version: '2.10'
   testImplementation project.deps.mockWebServer
   testImplementation project.deps.mockito


### PR DESCRIPTION
Removes noise from vulnerabilities on 1.11 version, and likely no compatibility issues.

- fixes #146