### PR TITLE
Switch to running builds within Docker

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -7,15 +7,18 @@ on: [ pull_request ]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Install yum/dnf/repoquery
-        run: sudo apt install yum-utils
       - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: addnab/docker-run-action@v3
         with:
-          java-version: 17
-          distribution: temurin
-      - name: Build with Gradle
-        run: ./gradlew assemble check
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: docker.io
+          image: eclipse-temurin:17-ubi9-minimal
+          options: >-
+            -v ${{ github.workspace }}:/work
+          run: |
+            microdnf install -y git findutils yum-utils
+            cd work
+            ./gradlew assemble check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,23 @@ on:
 jobs:
   build_and_release:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_USER:  "gocd"
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      PRERELEASE:   "${{ github.event.inputs.prerelease }}"
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: addnab/docker-run-action@v3
         with:
-          java-version: 17
-          distribution: temurin
-      - name: Release
-        run: ./gradlew verifyExpRelease githubRelease
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: docker.io
+          image: eclipse-temurin:17-ubi9-minimal
+          options: >- 
+            -v ${{ github.workspace }}:/work 
+            -e GITHUB_USER=gocd
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            -e PRERELEASE=${{ github.event.inputs.prerelease }}
+          run: |
+            microdnf install -y git findutils
+            cd work
+            ./gradlew verifyExpRelease githubRelease
+

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -9,18 +9,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Install yum/dnf/repoquery
-        run: sudo apt install yum-utils
       - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: addnab/docker-run-action@v3
         with:
-          java-version: 17
-          distribution: temurin
-      - name: Test with Gradle
-        run: ./gradlew assemble check
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: docker.io
+          image: eclipse-temurin:17-ubi9-minimal
+          options: >-
+            -v ${{ github.workspace }}:/work
+          run: |
+            microdnf install -y git findutils yum-utils
+            cd work
+            ./gradlew assemble check
   previewGithubRelease:
     needs: test
     runs-on: ubuntu-latest
@@ -31,10 +34,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: addnab/docker-run-action@v3
         with:
-          java-version: 17
-          distribution: temurin
-      - name: Test with Gradle
-        run: ./gradlew githubRelease
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: docker.io
+          image: eclipse-temurin:17-ubi9-minimal
+          options: >-
+            -v ${{ github.workspace }}:/work
+            -e GITHUB_USER=gocd
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          run: |
+            microdnf install -y git findutils
+            cd work
+            ./gradlew githubRelease
+

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 The Yum respository poller is a [package material](https://docs.gocd.org/current/extension_points/package_repository_extension.html) plugin capable of polling yum repositories for rpm packages. GoCD server interacts with this plugin via package material plugin interfaces. The plugin makes use of a command similar to the following to poll the server. So it does not depend on the files that yum depends on e.g. files under `/etc/yum.repos.d`
 
 ```
-repoquery --repofrompath=uuid,$REPO_URL --repoid=uuid -q $PACKAGE_SPEC -qf "%{LOCATION}..."
+dnf repoquery --repofrompath=uuid,$REPO_URL --repoid=uuid -q $PACKAGE_SPEC -qf "%{LOCATION}..."
 ```
 
-A given instance of polling is considered successful if `repoquery` returns a single package as output.
+A given instance of polling is considered successful if `dnf repoquery` returns a single package as output.
 
 ## Installation
 
@@ -15,7 +15,7 @@ per the [plugin user guide](https://docs.gocd.org/current/extension_points/plugi
 
 Prior to GoCD `23.1.0`, this plugin came bundled along with the GoCD server, and a separate installation is not required.
 
-> **Note:** This plugin is available for GoCD servers running on Linux nodes having `repoquery` installed using the  [`yum-utils`](http://linux.die.net/man/1/yum-utils) package, [Ubuntu](http://manpages.ubuntu.com/manpages/latest/man1/yum-utils.1.html), [CentOS](http://rpmfind.net/linux/rpm2html/search.php?query=yum-utils&system=centos))
+> **Note:** This plugin is available for GoCD servers running on Linux nodes having `dnf` installed.
 
 ## Repository definition
 
@@ -23,7 +23,7 @@ Repo URL must be a valid http, https or file URL. This plugin looks for the pres
 
 ## Package definition
 
-In case of this plugin, the package definition is completely determined by the package spec. The package spec may be in any of the following formats. Please refer to the [repoquery man page](https://linux.die.net/man/1/repoquery) for details.
+In case of this plugin, the package definition is completely determined by the package spec. The package spec may be in any of the following formats. Please refer to the [dnf repoquery docs](https://dnf.readthedocs.io/en/latest/command_ref.html#repoquery-command-label) for details.
 
 ```
 name

--- a/gocd-yum-repo-plugin/src/main/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommand.java
+++ b/gocd-yum-repo-plugin/src/main/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommand.java
@@ -55,7 +55,7 @@ public class RepoQueryCommand {
 
     public PackageRevisionMessage execute() {
         YumEnvironmentMap yumEnvironmentMap = new YumEnvironmentMap(params.getRepoId());
-        String[] command = {"repoquery",
+        String[] command = {"dnf", "repoquery",
                 "--repofrompath=" + params.getRepoFromId(),
                 "--repoid=" + params.getRepoId(),
                 "-q",

--- a/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
+++ b/gocd-yum-repo-plugin/src/test/java/com/tw/go/plugin/material/artifactrepository/yum/exec/command/RepoQueryCommandTest.java
@@ -192,7 +192,7 @@ public class RepoQueryCommandTest {
     }
 
     private String[] repoQueryCommand(String repoid, String spec, String repoFromPath) {
-        return new String[]{"repoquery",
+        return new String[]{"dnf", "repoquery",
                 "--repofrompath=" + repoFromPath,
                 "--repoid=" + repoid,
                 "-q",


### PR DESCRIPTION
Tests need access to dnf/repoquery. Previously there was a package for ubuntu 18 which worked fine, but it's not available for modern ubuntus.

Switch instead to using a Red Hat compatible docker image (ubi) instead.